### PR TITLE
Laravel Coding standard (PSR-2)

### DIFF
--- a/src/Console/Commands/ClearTranslationJsonCache.php
+++ b/src/Console/Commands/ClearTranslationJsonCache.php
@@ -19,7 +19,8 @@ class ClearTranslationJsonCache extends Command
      *
      * @var string
      */
-    protected $description = 'Deletes cached translation JSON-files, allowing them to be regenereted automatically on the next request.';
+    protected $description = 'Deletes cached translation JSON-files, 
+        allowing them to be regenereted automatically on the next request.';
 
     /**
      * Execute the console command.

--- a/tests/Feature/TranslationJsonCacheTest.php
+++ b/tests/Feature/TranslationJsonCacheTest.php
@@ -15,7 +15,7 @@ class TranslationJsonCacheTest extends TestCase
     }
 
     /** @test */
-    function the_cache_file_is_not_created_when_the_env_variable_is_false ()
+    function the_cache_file_is_not_created_when_the_env_variable_is_false()
     {
         config(['translation-json-cache.active' => false]);
 
@@ -25,7 +25,7 @@ class TranslationJsonCacheTest extends TestCase
     }
 
     /** @test */
-    function the_cache_file_is_not_created_when_the_env_variable_is_missing ()
+    function the_cache_file_is_not_created_when_the_env_variable_is_missing()
     {
         config(['translation-json-cache.active' => null]);
 
@@ -35,7 +35,7 @@ class TranslationJsonCacheTest extends TestCase
     }
 
     /** @test */
-    function the_cache_file_is_used_when_the_env_variable_is_set_to_true ()
+    function the_cache_file_is_used_when_the_env_variable_is_set_to_true()
     {
         Storage::put('translation-cache-en.php', '<?php return ["Test" => "Testing"];');
         config(['translation-json-cache.active' => true]);
@@ -44,7 +44,7 @@ class TranslationJsonCacheTest extends TestCase
     }
 
     /** @test */
-    function the_cache_file_is_not_used_when_the_env_variable_is_set_to_false ()
+    function the_cache_file_is_not_used_when_the_env_variable_is_set_to_false()
     {
         Storage::put('translation-cache-en.php', '<?php return ["Test" => "Testing"];');
         config(['translation-json-cache.active' => false]);
@@ -53,7 +53,7 @@ class TranslationJsonCacheTest extends TestCase
     }
 
     /** @test */
-    function the_cache_file_is_not_used_when_the_env_variable_is_missing ()
+    function the_cache_file_is_not_used_when_the_env_variable_is_missing()
     {
         Storage::put('translation-cache-en.php', '<?php return ["Test" => "Testing"];');
         config(['translation-json-cache.active' => null]);
@@ -62,7 +62,7 @@ class TranslationJsonCacheTest extends TestCase
     }
 
     /** @test */
-    function the_data_in_the_cached_file_corresponds_to_the_json_file ()
+    function the_data_in_the_cached_file_corresponds_to_the_json_file()
     {
         file_put_contents(base_path() . '/resources/lang/en.json', '{"Test":"Testing"}');
         config(['translation-json-cache.active' => true]);
@@ -74,7 +74,7 @@ class TranslationJsonCacheTest extends TestCase
     }
 
     /** @test */
-    function the_cached_file_takes_presendece_if_it_differs_from_the_json_file ()
+    function the_cached_file_takes_presendece_if_it_differs_from_the_json_file()
     {
         file_put_contents(base_path() . '/resources/lang/en.json', '{"Test":"Testing"}');
         file_put_contents(storage_path() . '/app/translation-cache-en.php', '<?php return ["Test" => "Testing2"];');


### PR DESCRIPTION
Updates current project files to follow the PSR-2 coding standard, which Laravel follows.
Tests passes.